### PR TITLE
first-use: redirect to /login instead of /

### DIFF
--- a/first-use/main.js
+++ b/first-use/main.js
@@ -1,6 +1,6 @@
 /* global $, ga */
 
-var app_location = 'https://app.simplyhomework.nl/';
+var app_location = 'https://app.simplyhomework.nl/login';
 var owl;
 
 $(document).ready(function (){


### PR DESCRIPTION
/login is a nonapp/nologin route, this means that the user won't be redirected
to www.simplyhomework.nl. Which could happen when some localstorage state hasn't
been set correctly. This forces the user to click the login button on the
homepage again, not a disaster but this is nicer.